### PR TITLE
Handling of missing linker symbols for WASI builds

### DIFF
--- a/libgm/tools/gmpack.cpp
+++ b/libgm/tools/gmpack.cpp
@@ -24,6 +24,7 @@
 #include <iostream>
 #include <stdexcept>
 #include <streambuf>
+#include "wasmexcept.hpp"
 #include "Bitstream.hpp"
 #include "Chip.hpp"
 #include "ChipConfig.hpp"

--- a/libgm/tools/gmunpack.cpp
+++ b/libgm/tools/gmunpack.cpp
@@ -23,6 +23,7 @@
 #include <iostream>
 #include <stdexcept>
 #include <streambuf>
+#include "wasmexcept.hpp"
 #include "Bitstream.hpp"
 #include "Chip.hpp"
 #include "ChipConfig.hpp"

--- a/libgm/tools/wasmexcept.hpp
+++ b/libgm/tools/wasmexcept.hpp
@@ -1,0 +1,25 @@
+#if defined(__wasm)
+
+#include <cstdint>
+#include <iostream>
+
+extern "C" {
+// FIXME: WASI does not currently support exceptions.
+void *__cxa_allocate_exception(size_t thrown_size) throw() { return malloc(thrown_size); }
+bool __cxa_uncaught_exception() throw();
+void __cxa_throw(void *thrown_exception, struct std::type_info *tinfo, void (*dest)(void *)) { (void)thrown_exception; (void)tinfo; (void)dest; std::terminate(); }
+}
+
+namespace boost {
+struct source_location;
+void throw_exception(std::exception const &e) { 
+	std::cerr << "boost::exception(): " << e.what() << std::endl;
+	exit(1);
+}
+void throw_exception(std::exception const &e, boost::source_location const &) { 
+	std::cerr << "boost::exception(): " << e.what() << std::endl;
+	exit(1);
+}
+} // namespace boost
+
+#endif


### PR DESCRIPTION
This PR allows to compile and link `gmpack` and `gmunpack` for WASI, enabling support for a yowasp-himbaechel-gatemate package. Without these changes, the linker complains about missing symbols relating to exceptions. The fix follows the same approach as prjtrellis.

Changes:
- Added header `libgm/tools/wasmexcept.hpp` (from prjtrellis). This header has no effect unless compiling with `__wasm`.
- Included the header in `libgm/tools/gmpack.cpp` and `libgm/tools/gmunpack.cpp`.
