### PR TITLE
cmake: adding an existence check around FindBoost policy (CMP0167)

### DIFF
--- a/libgm/CMakeLists.txt
+++ b/libgm/CMakeLists.txt
@@ -1,7 +1,10 @@
 cmake_minimum_required(VERSION 3.13)
 project(libgatemate)
 
-cmake_policy(SET CMP0167 NEW)
+if (POLICY CMP0167)
+  # The existence check above avoids breaking the build on older cmake versions
+  cmake_policy(SET CMP0167 NEW)
+endif()
 
 option(BUILD_SHARED "Build shared GateMate library" OFF)
 option(STATIC_BUILD "Create static build of GateMate tools" ON)


### PR DESCRIPTION
This PR adds an existence check around the `cmake_policy(SET CMP0167 NEW)` policy setting. This avoids breaking build systems using CMake prior to 3.30, in particular when these cannot be easily upgraded (i.e. complex CI builds).

Edit: Just to add context ; this is for instance necessary for the yowasp-nextpnr-himbaechel-gatemate CI, and on still-current Ubuntu such as 24.04.4 LTS. 
The build still works fine when skipping this policy setting with CMake 3.28.