### PR TITLE
gmpack: `CMD_PLL` requires Die::PLL_CFG_SIZE (12) NOPs

### DIFF
--- a/libgm/src/Bitstream.cpp
+++ b/libgm/src/Bitstream.cpp
@@ -377,7 +377,7 @@ class BitstreamReadWriter
         for (int i = pos; i < pos + size - Die::PLL_CFG_SIZE; i++)
             write_byte(data[i]);
         insert_crc16();
-        write_nops(6);
+        write_nops(Die::PLL_CFG_SIZE);
     }
 
     void write_cmd_chg_status(uint8_t data)


### PR DESCRIPTION
After every `CMD_PLL` command, there must be at least as many NOPs as the configuration is long. This isn't noticeable in single- and dual-SPI modes, but it is in the quad-SPI mode. Without sufficient NOPs, the PLL configuration is incomplete.